### PR TITLE
MANTA-5471 Allow passthrough of AWS Signature V4 requests to manta-buckets-api

### DIFF
--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -70,7 +70,7 @@ frontend https
         # AWS S3 API compatibility - route SigV4 requests to buckets_api
         acl acl_aws_sigv4 req.hdr(authorization) -m beg "AWS4-HMAC-SHA256"
         use_backend buckets_api if acl_aws_sigv4
-        
+
         # Existing Manta bucket routing (unchanged)
         acl acl_bucket path_reg ^/[^/]+/buckets
         use_backend buckets_api if acl_bucket

--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -68,6 +68,8 @@ frontend https
         http-response deny if { res.hdr_cnt(content-length) gt 1 }
 
         # AWS S3 API compatibility - route SigV4 requests to buckets_api
+        # If for some reason any other back end uses SigV4 in the future,
+        # we will have to revisit this section.
         acl acl_aws_sigv4 req.hdr(authorization) -m beg "AWS4-HMAC-SHA256"
         use_backend buckets_api if acl_aws_sigv4
 

--- a/etc/haproxy.cfg.in
+++ b/etc/haproxy.cfg.in
@@ -67,6 +67,11 @@ frontend https
         http-request  deny if { req.hdr_cnt(content-length) gt 1 }
         http-response deny if { res.hdr_cnt(content-length) gt 1 }
 
+        # AWS S3 API compatibility - route SigV4 requests to buckets_api
+        acl acl_aws_sigv4 req.hdr(authorization) -m beg "AWS4-HMAC-SHA256"
+        use_backend buckets_api if acl_aws_sigv4
+        
+        # Existing Manta bucket routing (unchanged)
         acl acl_bucket path_reg ^/[^/]+/buckets
         use_backend buckets_api if acl_bucket
         default_backend secure_api

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "muppet",
   "description": "Manta's Load Balancer",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "author": "MNX Cloud (mnx.io)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
We need to pass through SigV4 requests to the manta-buckets-api to service S3 requests, not impacting the rest of the routes.